### PR TITLE
Fix http xhr lib to work with require.js

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -26,7 +26,7 @@
 
   var xhr = function (type, url, data) {
       var promise = new Promise(function (resolve, reject) {
-          var XHR = root.XMLHttpRequest || ActiveXObject;
+          var XHR = XMLHttpRequest || ActiveXObject;
           var request = new XHR('MSXML2.XMLHTTP.3.0');
 
           request.open(type, url, true);


### PR DESCRIPTION
Minor code change to fix incompatibility with require.js. Reference to `XMLHttpRequest` was relative to provided `root` object, which is unnecessary and breaking in require.js. I don't *think* there's a case where you'd want to use anything other than `window` here.