### PR TITLE
Minor changes to tutorial doc, and updated links. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open MCT Integration Tutorials
 
-These tutorials will walk you through the simple process of integrating your telemetry systems with Open MCT.  In case you don't have any telemetry systems, we've included a reference implementation of a historical and realtime server.  We'll walk you through the process of integrating those services with Open MCT.
+These tutorials will walk you through the simple process of integrating your telemetry systems with Open MCT.  In case you don't have any telemetry systems, we've included a reference implementation of a historical and realtime server.  We'll take you through the process of integrating those services with Open MCT.
 
 ## Tutorial Prerequisites
 
@@ -30,15 +30,19 @@ npm install
 npm start
 ```
 
-This will clone the tutorials and install Open MCT from NPM.  It will also install the dependencies needed to run the reference implementation of a telemetry server, and then it will start the tutorial server.
+This will clone the tutorials and install Open MCT from NPM.  It will also install the dependencies needed to run the provided telemetry server. The last command will start the server. The telemetry server provided is for demonstration purposes only, and is not intended to be used in a production environment.
 
-At this point, you will be able to browse the tutorials in their completed state.  However, if you would like to follow along, you can skip to specific steps in the tutorial at any point by typing
+At this point, you will be able to browse the tutorials in their completed state.  We have also tagged the repository at each step of the tutorial, so it is possible to skip to a particular step using git checkout.
+
+eg.
 
 ```
 git checkout -f part-X-step-N
 ```
 
 Substituting the appropriate part and step numbers as necessary.
+
+The recommended way of following the tutorials is to checkout the first step (the command is shown below), and then follow the tutorial by manually adding the code, but if you do get stuch you can use the tags to skip ahead. If you do get stuck, please let us know by [filing in issue in this repository](https://github.com/nasa/openmct-tutorial/issues/new) so that we can improve the tutorials.
 
 ## Part A: Running Open MCT
 **Shortcut**: `git checkout -f part-a`
@@ -67,7 +71,9 @@ We're going to define a single `index.html` page.  We'll include the Open MCT li
 </html>
 ```
 
-We have provided a basic server for the purpose of this tutorial, which will act as a web server as well as a telemetry source. If the serer is not already running, run it now -
+We have provided a basic server for the purpose of this tutorial, which will act as a web server as well as a telemetry source. This server is for demonstration purposes only. The Open MCT web client can be hosted on any http server. 
+
+If the server is not already running, run it now -
 
 ```
 npm start
@@ -90,7 +96,7 @@ The object tree is a hierarchical representation of all of the objects available
 ## Step 1 - Defining a new plugin
 **Shortcut:** `git checkout -f part-b-step-1`
 
-Let's start by creating a new plugin to populate the object tree. We will encapsulate the code for this plugin in a new javascript file named `dictionary-plugin.js`. We'll then install that plugin into Open MCT to validate that we are loading the plugin
+Let's start by creating a new plugin to populate the object tree. We will include all of the code for this plugin in a new javascript file named `dictionary-plugin.js`. Let's first create a very basic plugin that simply logs a message indicating that it's been installed.
 
 [dictionary-plugin.js](https://github.com/nasa/openmct-tutorial/blob/part-b-step-2/dictionary-plugin.js)
 ```javascript
@@ -101,7 +107,7 @@ function DictionaryPlugin() {
 };
 ```
 
-Then, we'll update index.html to include the file:
+Next, we'll update index.html to include the file:
 
 [index.html](https://github.com/nasa/openmct-tutorial/blob/part-b-step-2/index.html)
 ```html
@@ -138,7 +144,7 @@ The process of opening a javascript console differs depending on the browser bei
 
 In summary, an Open MCT plugin is very simple: it's an initialization function which receives the Open MCT API as the single argument.  It then uses the provided API to extend Open MCT.  Generally, we like plugins to return an initialization function so they can receive configuration.
 
-[Learn more about plugins here](api/plugin-overview.md)
+[Learn more about plugins here](https://github.com/nasa/openmct/blob/master/API.md#plugins)
 
 ## Step 2 - Creating a new root node
 **Shortcut:** `git checkout -f part-b-step-2`
@@ -157,18 +163,18 @@ function DictionaryPlugin() {
 };
 ```
 
-A new root is added to the object tree using the `addRoot` function exposed by the Open MCT API. `addRoot` accepts an object identifier - defined as a javascript object with a `namespace` and a `key` attribute.
+A new root is added to the object tree using the `addRoot` function exposed by the Open MCT API. `addRoot` accepts an object identifier - defined as a javascript object with a `namespace` and a `key` attribute. [More information on objects and identifiers](https://github.com/nasa/openmct/blob/master/API.md#domain-objects-and-identifiers) is available in our API.
 
 If we reload the browser now, we should see a new object in the tree.
  
  ![Open MCT](images/openmct-missing-root.png)
  
- Currently it will appear as a question mark with `Missing: example.taxonomy:spacecraft` next to it. This is because for now all we've done is provide an identifier for the root node. In the next step, we will define an Object Provider, which will provide Open MCT with an object for this identifier.
+ Currently it will appear as a question mark with `Missing: example.taxonomy:spacecraft` next to it. This is because for now all we've done is provide an identifier for the root node. In the next step, we will define an __Object Provider__, which will provide Open MCT with an object for this identifier. A [basic overview of object providers](https://github.com/nasa/openmct/blob/master/API.md#object-providers) is available in our API documentation.
 
 ## Step 3 - Providing objects
 **Shortcut:** `git checkout -f part-b-step-3`
 
-Now we will start populating the tree with objects. To do so, we will define an Object Provider. An object provider receives an object identifier, and returns a promise that resolve with an object for the given identifier (if available).  In this step we will produce some objects to represent the parts of the spacecraft that produce telemetry data, such as subsystems and instruments. Let's call these telemetry producing things "telemetry points". Below some code defining and registering an object provider for the new `spacecraft` root object:
+Now we will start populating the tree with objects. To do so, we will define an object provider. An Object Provider receives an object identifier, and returns a promise that resolve with an object for the given identifier (if available).  In this step we will produce some objects to represent the parts of the spacecraft that produce telemetry data, such as subsystems and instruments. Let's call these telemetry producing things __telemetry points__. Below some code defining and registering an object provider for the new "spacecraft" root object:
 
 [dictionary-plugin.js](https://github.com/nasa/openmct-tutorial/blob/part-b-step-4/dictionary-plugin.js)
 ```javascript
@@ -206,7 +212,7 @@ function DictionaryPlugin() {
 };
 ```
 
-If we reload our browser now, the unknown object in our tree should be replaced with an object named `Example Spacecraft` with a folder icon. 
+If we reload our browser now, the unknown object in our tree should be replaced with an object named "Example Spacecraft" with a folder icon. 
 
 ![Open MCT with new Spacecraft root](images/openmct-root-folder.png)
 
@@ -221,7 +227,7 @@ openmct.types.addType('example.telemetry', {
 });
 ```
 
-Here we define a new type with a key of `example.telemetry`. For details on the attributes used to specify a new Type, please [see our documentation on object Types]()
+Here we define a new type with a key of `example.telemetry`. For details on the attributes used to specify a new Type, please [see our documentation on object Types](https://github.com/nasa/openmct/blob/master/API.md#domain-object-types)
  
 Finally, let's modify our object provider to return objects of our newly registered type. Our dictionary plugin will now look like this:
 
@@ -272,12 +278,12 @@ function DictionaryPlugin() {
 };
 ```
 
-Although we have now defined an object provider for both the Example Spacecraft and its children (the telemetry measurements) if we refresh our browser at this point, we won't see any more objects in the tree. This is because we haven't defined the structure of the tree yet.
+Although we have now defined an Object Provider for both the "Example Spacecraft" and its children (the telemetry measurements), if we refresh our browser at this point we won't see any more objects in the tree. This is because we haven't defined the structure of the tree yet.
 
 ## Step 4 - Populating the tree
 **Shortcut:** `git checkout -f part-b-step-4`
 
-We have defined a root node in [Step 2](https://github.com/nasa/openmct-tutorial/blob/part-b-step-3/dictionary-plugin.js) and we have provided some objects that will appear in the tree. Now we will provide structure to the tree and define the relationships between objects in the tree. This is achieved with a [Composition Provider]().
+We have defined a root node in [Step 2](https://github.com/nasa/openmct-tutorial/blob/part-b-step-3/dictionary-plugin.js) and we have provided some objects that will appear in the tree. Now we will provide structure to the tree and define the relationships between objects in the tree. This is achieved with a __[Composition Provider](https://github.com/nasa/openmct/blob/master/API.md#composition-providers)__.
 
 Snippet from [dictionary-plugin.js](https://github.com/nasa/openmct-tutorial/blob/part-c/dictionary-plugin.js#L34-L50)
 ```javascript
@@ -301,7 +307,7 @@ var compositionProvider = {
 
 openmct.composition.addProvider(compositionProvider);
 ```
-A composition provider accepts a Domain Object, and provides identifiers for the children of that object. For the purposes of this tutorial we will return identifiers for the telemetry points available from our spacecraft. We build these from our spacecraft telemetry dictionary file.
+A Composition Provider accepts a Domain Object, and provides identifiers for the children of that object. For the purposes of this tutorial we will return identifiers for the telemetry points available from our spacecraft. We build these from our spacecraft telemetry dictionary file.
 
 Our plugin should now look like this -
 
@@ -387,7 +393,7 @@ Clicking on our telemetry points will display views of those objects, but for no
 # Part C - Integrate/Provide/Request Telemetry
 **Shortcut:** `git checkout -f part-c`
 
-Open MCT supports receiving telemetry by interrogating a telemetry store, and by subscribing to real-time telemetry updates. In this part of the tutorial we will define and register a telemetry adapter for retrieving historical telemetry from our tutorial telemetry server. Let's define our plugin in a new file named `historical-telemetry-plugin.js`
+Open MCT supports receiving telemetry by requesting data from a telemetry store, and by subscribing to real-time telemetry updates. In this part of the tutorial we will define and register a telemetry adapter for requesting historical telemetry from our tutorial telemetry server. Let's define our plugin in a new file named `historical-telemetry-plugin.js`
 
 [historical-telemetry-plugin.js](https://github.com/nasa/openmct-tutorial/blob/part-d/historical-telemetry-plugin.js)
 ```javascript
@@ -452,12 +458,12 @@ With our adapter defined, we need to update `index.html` to include it.
 </html>
 ```
 
-At this point If we refresh the page we should now see some telemetry for our telemetry points. For example, navigating to the 'Generator Temperature' telemetry point should show us a plot of the telemetry generated since the server started running. It should look something like the screenshot below.
+At this point If we refresh the page we should now see some telemetry for our telemetry points. For example, navigating to the "Generator Temperature" telemetry point should show us a plot of the telemetry generated since the server started running.
 
 # Part D - Subscribing to New Telemetry
 **Shortcut:** `git checkout -f part-d`
 
-We are now going to define a telemetry adapter that allows Open MCT to subscribe to our tutorial server for new telemetry as it becomes available. The process of defining a telemetry adapter for subscribing to real-time telemetry is similar to our previous adapter, except that we define a `supportsSubscribe` function to indicate that this adapter provides telemetry subscriptions, and a `subscribe` function. This adapter uses a simple messaging system for subscribing to telemetry updates over a websocket. 
+We are now going to define a telemetry adapter that allows Open MCT to subscribe to our tutorial server for new telemetry as it becomes available. The process of defining a telemetry adapter for subscribing to real-time telemetry is similar to our previously defined historical telemetry adapter, except that we define a `supportsSubscribe` function to indicate that this adapter provides telemetry subscriptions, and a `subscribe` function for subscribing to updates. This adapter uses a simple messaging system for subscribing to telemetry updates over a websocket. 
 
 Let's define our new plugin in a file named `realtime-telemetry-plugin.js`.
 
@@ -510,7 +516,7 @@ function RealtimeTelemetryPlugin() {
 }
 ```
 
-The subscribe function accepts as arguments the domain object for which we are interested in telemetry, and a callback function. The callback function will be invoked with telemetry data as they become available.
+The subscribe function accepts as arguments the Domain Object for which we are interested in telemetry, and a callback function. The callback function will be invoked with telemetry data as they become available.
 
 With our realtime telemetry plugin defined, let's include it from `index.html`.
 
@@ -543,10 +549,4 @@ With our realtime telemetry plugin defined, let's include it from `index.html`.
 </html>
 ```
 
-If we refresh the page, and navigate to one of our telemetry points, we should now see telemetry flowing. For example, navigating to the 'Generator Temperature' telemetry point should show us a plot of the telemetry point's telemetry that is updated regularly with new telemetry data.
-
-## Glossary
-
-* Domain Object: An object is anything that can be represented in Open MCT. Telemetry sources, telemetry points, and views for visualizing telemetry data are all represented as objects in Open MCT. Objects are displayed in a tree in Open MCT, and allow a user to view telemetry data, and compose layouts from multiple view objects.
-* Telemetry Source: A service that provides telemetry. Telemetry can be provided in response to a request, or as a subscription. 
-* Telemetry Point: A telemetry point is a `thing` about which telemetry values are produced by a telemetry source. For example, a telemetry source might expose telemetry points for various instruments and subsystems on a spacecraft as telemetry points.
+If we refresh the page and navigate to one of our telemetry points we should now see telemetry flowing. For example, navigating to the "Generator Temperature" telemetry point should show us a plot of telemetry data that is now updated regularly.


### PR DESCRIPTION
This is in support of https://github.com/nasa/openmct/issues/1473

Links to API will be invalid until [updated API docs](https://github.com/nasa/openmct/blob/updated-docs/API.md) are merged into master.

## Author Checklist

* Changes address original issue? Y
* Unit tests included and/or updated with changes? N/A docs only
* Command line build passes? N/A no command-line build
* Changes have been smoke-tested? N/A docs only