### PR TITLE
Update dictionary to match telemetry and spec

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -11,13 +11,16 @@
                     "name": "Value",
                     "units": "kilograms",
                     "format": "float",
+                    "min": 0,
+                    "max": 100,
                     "hints": {
                         "y": 1,
                         "range": 1
                     }
                 },
                 {
-                    "key": "timestamp",
+                    "key": "utc",
+                    "source": "timestamp",
                     "name": "Timestamp",
                     "format": "utc",
                     "hints": {
@@ -37,11 +40,11 @@
                     "format": "enum",
                     "enumerations": [
                         {
-                            "string": "On",
+                            "string": "ON",
                             "value": 1
                         },
                         {
-                            "string": "Off",
+                            "string": "OFF",
                             "value": 0
                         }
                     ],
@@ -51,7 +54,8 @@
                     }
                 },
                 {
-                    "key": "timestamp",
+                    "key": "utc",
+                    "source": "timestamp",
                     "name": "Timestamp",
                     "format": "utc",
                     "hints": {
@@ -76,7 +80,8 @@
                     }
                 },
                 {
-                    "key": "timestamp",
+                    "key": "utc",
+                    "source": "timestamp",
                     "name": "Timestamp",
                     "format": "utc",
                     "hints": {
@@ -101,7 +106,8 @@
                     }
                 },
                 {
-                    "key": "timestamp",
+                    "key": "utc",
+                    "source": "timestamp",
                     "name": "Timestamp",
                     "format": "utc",
                     "hints": {
@@ -126,7 +132,8 @@
                     }
                 },
                 {
-                    "key": "timestamp",
+                    "key": "utc",
+                    "source": "timestamp",
                     "name": "Timestamp",
                     "format": "utc",
                     "hints": {
@@ -151,7 +158,8 @@
                     }
                 },
                 {
-                    "key": "timestamp",
+                    "key": "utc",
+                    "source": "timestamp",
                     "name": "Timestamp",
                     "format": "utc",
                     "hints": {
@@ -176,7 +184,8 @@
                     }
                 },
                 {
-                    "key": "timestamp",
+                    "key": "utc",
+                    "source": "timestamp",
                     "name": "Timestamp",
                     "format": "utc",
                     "hints": {


### PR DESCRIPTION
Updates the telemetry metadata to exercise the API more and fix some problems with enumerations and time handling-- especially for table sorting and plots.

For timestamp values metadata, the `key` needs to match the timesystem's key (in this case, `utc`) such that plots and tables are able to determine the correct sort order of data.  I'm using the optional `source` attribute which causes OpenMCT to fetch `utc` values from the `timestamp`-- it would otherwise default to `utc`.

I also fixed the enumeration names to match the telemetry data, and added a `min` and `max` to the fuel measurement so the plot can intelligently set y axis bounds.

@akhenry take a look, merge if you like.