### PR TITLE
[Open MCT Dependency] Update from GitHub repo to NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "express": "^4.16.4",
     "express-ws": "^4.0.0",
-    "openmct": "https://github.com/nasa/openmct.git",
+    "openmct": "nasa/openmct",
     "ws": "^6.1.2"
   }
 }


### PR DESCRIPTION
Simple update to try to prevent errors when installing Open MCT from GitHub. Updated to us our NPM package.

closes #41 